### PR TITLE
fix: prioritize Indian date format (DD/MM/YYYY) over US format in date parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,13 +60,13 @@ tests/                  # Test suite
 ### Development Commands
 ```bash
 # Run CLI tool (organized output - default)
-cd src && python3 -m debrokly.cli ../samples/pdfs/HDFC-Statement.pdf
+cd src && source ../.venv/bin/activate && python3 -m debrokly.cli ../samples/pdfs/HDFC-Statement.pdf
 
 # Custom output location
-cd src && python3 -m debrokly.cli ../samples/pdfs/HDFC-Statement.pdf --output ../my_file.csv --no-organized
+cd src && source ../.venv/bin/activate && python3 -m debrokly.cli ../samples/pdfs/HDFC-Statement.pdf --output ../my_file.csv --no-organized
 
 # Excel format with password
-cd src && python3 -m debrokly.cli ../samples/pdfs/protected.pdf --password mypass --format excel
+cd src && source ../.venv/bin/activate && python3 -m debrokly.cli ../samples/pdfs/protected.pdf --password mypass --format excel
 
 # Run tests (when implemented)
 pytest
@@ -77,6 +77,51 @@ flake8 src/ tests/
 
 # Type checking (when configured)
 mypy src/
+```
+
+## Testing Commands
+
+### Basic Testing Commands
+```bash
+# Basic test with organized output (recommended)
+cd src && source ../.venv/bin/activate && python3 -m debrokly.cli ../samples/pdfs/[FILENAME].pdf
+
+# Test with custom output location
+cd src && source ../.venv/bin/activate && python3 -m debrokly.cli ../samples/pdfs/[FILENAME].pdf --output ../test_output.csv --no-organized
+
+# Test with Excel format
+cd src && source ../.venv/bin/activate && python3 -m debrokly.cli ../samples/pdfs/[FILENAME].pdf --format excel --no-organized
+
+# Test password-protected PDFs
+cd src && source ../.venv/bin/activate && python3 -m debrokly.cli ../samples/pdfs/[FILENAME].pdf --password yourpassword
+```
+
+### Quick Test All HDFC Files
+```bash
+cd src && source ../.venv/bin/activate
+python3 -m debrokly.cli ../samples/pdfs/HDFC-Statement.pdf --no-organized
+python3 -m debrokly.cli ../samples/pdfs/HDFC-Statement-2.pdf --no-organized  
+python3 -m debrokly.cli ../samples/pdfs/hdfc_may_millennia.pdf --no-organized
+```
+
+### Available Sample Files
+- `HDFC-Statement.pdf` - Original HDFC test file (5 transactions)
+- `HDFC-Statement-2.pdf` - Extended HDFC test file (17 transactions) 
+- `hdfc_may_millennia.pdf` - HDFC May statement (9 transactions)
+- `AUBANK.pdf` - AU Bank test file (extraction in development)
+
+### Testing Results Verification
+After running any test, check the generated CSV/Excel files to verify:
+- **Date Parsing**: Dates should follow DD/MM/YYYY format and be correctly parsed
+- **Transaction Count**: Match expected number of transactions
+- **Amount Parsing**: Debits should be negative, credits positive
+- **Description Cleaning**: Text should be clean and readable
+
+**Example Expected Output:**
+```csv
+date,description,amount,type,balance,bank,raw_data
+2025-06-04,Flipkart Internet Private Bengaluru,-1412.0,debit,,hdfc,...
+2025-05-27,CC PAYMENT 728325781258 PayZapp,...,17706.01,credit,,hdfc,...
 ```
 
 ### Working Features (as of current implementation)

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -85,13 +85,22 @@
 ### Sample Data
 - User will provide sample PDFs from different banks for testing and development
 - Use samples to refine parsing algorithms and format detection
-
 ### Success Criteria
 - Successfully extract transaction data from major bank statement formats
 - Reliable password-protected PDF handling
 - Clean CSV/Excel export functionality
 - Easy integration as Python library
 - Robust error handling for edge cases
+
+
+### Quick Test All HDFC Files
+```bash
+cd src && source ../.venv/bin/activate
+python3 -m debrokly.cli ../samples/pdfs/HDFC-Statement.pdf --no-organized
+python3 -m debrokly.cli ../samples/pdfs/HDFC-Statement-2.pdf --no-organized  
+python3 -m debrokly.cli ../samples/pdfs/hdfc_may_millennia.pdf --no-organized
+```
+
 
 ---
 *Document Version: 1.0*  

--- a/src/debrokly/utils/helpers.py
+++ b/src/debrokly/utils/helpers.py
@@ -37,17 +37,19 @@ def parse_date(date_str: str) -> Optional[date]:
     if not date_str or not isinstance(date_str, str):
         return None
     
-    # Common date formats to try
+    # Common date formats to try (Indian formats first for banking context)
     date_formats = [
-        '%m/%d/%Y',    # MM/DD/YYYY
-        '%m/%d/%y',    # MM/DD/YY
-        '%d/%m/%Y',    # DD/MM/YYYY
+        '%d/%m/%Y',    # DD/MM/YYYY (Indian format - priority for banking)
         '%d/%m/%y',    # DD/MM/YY
-        '%Y-%m-%d',    # YYYY-MM-DD
-        '%d %b %Y',    # DD MMM YYYY
-        '%b %d %Y',    # MMM DD YYYY
         '%d-%m-%Y',    # DD-MM-YYYY
+        '%d-%m-%y',    # DD-MM-YY
+        '%d %b %Y',    # DD MMM YYYY
+        '%d %B %Y',    # DD MMMM YYYY (full month name)
+        '%Y-%m-%d',    # YYYY-MM-DD (ISO format)
+        '%m/%d/%Y',    # MM/DD/YYYY (US format - lower priority)
+        '%m/%d/%y',    # MM/DD/YY
         '%m-%d-%Y',    # MM-DD-YYYY
+        '%b %d %Y',    # MMM DD YYYY
     ]
     
     date_str = date_str.strip()


### PR DESCRIPTION
Resolves issue #3 where ambiguous dates like '04/06/2025' were incorrectly parsed as April 6th instead of June 4th due to MM/DD/YYYY format taking priority over DD/MM/YYYY format in Indian banking context.

Changes:
- Reordered date format priority in parse_date() to put DD/MM/YYYY first
- Added DD/MM/YY, DD-MM-YYYY variants with high priority
- Moved US formats (MM/DD/YYYY) to lower priority
- Added full month name support (%d %B %Y)

🤖 Generated with [Claude Code](https://claude.ai/code)